### PR TITLE
Tidal Plugin #26: Enable add/remove tracks to/from fav

### DIFF
--- a/src/mediaserver/cdplugins/tidal/constants.py
+++ b/src/mediaserver/cdplugins/tidal/constants.py
@@ -20,8 +20,11 @@ tidal_plugin_release : str = "0.4.0-trunk"
 listening_queue_action_key : str = "action"
 listening_queue_button_title_key : str = "button_title"
 
-listening_queue_action_add : str = "add"
-listening_queue_action_del : str = "del"
+__add_action : str = "add"
+__del_action : str = "del"
+
+listening_queue_action_add : str = __add_action
+listening_queue_action_del : str = __del_action
 
 listening_queue_action_add_dict : dict[str, str] = {
     listening_queue_action_key: listening_queue_action_add,
@@ -30,6 +33,25 @@ listening_queue_action_add_dict : dict[str, str] = {
 listening_queue_action_del_dict : dict[str, str] = {
     listening_queue_action_key: listening_queue_action_del,
     listening_queue_button_title_key: "Remove from Listening Queue"}
+
+fav_action_key : str = "action"
+fav_button_title_key : str = "button_title"
+
+fav_action_add : str = __add_action
+fav_action_del : str = __del_action
+
+fav_action_add_dict : dict[str, str] = {
+    fav_action_key: fav_action_add,
+    fav_button_title_key: "Add to Favorites"}
+
+fav_action_del_dict : dict[str, str] = {
+    fav_action_key: fav_action_del,
+    fav_button_title_key: "Remove from Favorites"}
+
+fav_action_dict : dict[str, any] = {
+    fav_action_add : fav_action_add_dict,
+    fav_action_del : fav_action_del_dict
+}
 
 featured_type_name_playlist : str = "PLAYLIST"
 tile_image_expiration_time_sec : int = 86400

--- a/src/mediaserver/cdplugins/tidal/element_type.py
+++ b/src/mediaserver/cdplugins/tidal/element_type.py
@@ -73,6 +73,7 @@ class ElementType(Enum):
     ALBUM_LISTEN_QUEUE_ACTION = 54, "lbmlqctn"
     ALBUM_LISTEN_QUEUE = 55, "lbllstnq"
     ALBUM_TRACKS = 56, "lbmtrks"
+    TRACK_FAVORITE_ACTION = 57, "trkfvtct"
     TRACK = 101, "trk"
     TRACK_CONTAINER = 102, "trkc"
 

--- a/src/mediaserver/cdplugins/tidal/item_identifier_key.py
+++ b/src/mediaserver/cdplugins/tidal/item_identifier_key.py
@@ -34,6 +34,7 @@ class ItemIdentifierKey(Enum):
     UNDERLYING_TYPE = 17, "ut"
     LISTEN_QUEUE_ACTION = 18, "lqctn"
     LAST_FOUND_ID = 19, "lfid"
+    FAVORITE_ACTION = 20, "fvctn"
 
     def __init__(self,
             num : int,

--- a/src/mediaserver/cdplugins/tidal/persistence.py
+++ b/src/mediaserver/cdplugins/tidal/persistence.py
@@ -783,28 +783,30 @@ def album_has_been_played(album_id : str) -> bool:
     cursor = __connection.cursor()
     cursor.execute("SELECT album_id, COUNT(album_id) \
                 FROM played_track_v1 \
-                WHERE album_id = ? \
+                WHERE \
+                    album_id = ? AND \
+                    play_count > 0 \
                 GROUP BY album_id", t)
     rows = cursor.fetchall()
     cursor.close()
     return rows and len(rows) == 1 and int(rows[0][1]) > 0
 
 
-def delete_album_from_played_tracks(album_id : str):
+def remove_album_from_played_tracks(album_id : str):
     t = (album_id,)
     cursor = __connection.cursor()
     cursor.execute(
-        "DELETE FROM played_track_v1 WHERE album_id = ?",
+        "UPDATE played_track_v1 SET play_count = 0, last_played = NULL WHERE album_id = ?",
         t)
     cursor.close()
     __connection.commit()
 
 
-def delete_track_from_played_tracks(track_id : str):
+def remove_track_from_played_tracks(track_id : str):
     t = (track_id,)
     cursor = __connection.cursor()
     cursor.execute(
-        "DELETE FROM played_track_v1 WHERE track_id = ?",
+        "UPDATE played_track_v1 SET play_count = 0, last_played = NULL WHERE track_id = ?",
         t)
     cursor.close()
     __connection.commit()


### PR DESCRIPTION
- also corrected remove from stats, just reset counter